### PR TITLE
fix: Fix build error

### DIFF
--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -8,6 +8,7 @@
   },
   "exclude": [
     "test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "app/utils"
   ]
 }


### PR DESCRIPTION
- files in `src/app/utils` are for tests, so it should be excluded from app build

Here is the build log without this commit.
```
> testing-patterns@0.0.0 build C:\angular-testing-recipes
> ng build

Browserslist: caniuse-lite is outdated. Please run next command `npm update`

Date: 2019-08-06T13:47:40.592Z
Hash: 3e9fc52d966f2ee82ad1
Time: 4670ms
chunk {main} main.js, main.js.map (main) 647 bytes [initial] [rendered]
chunk {polyfills} polyfills.js, polyfills.js.map (polyfills) 93.1 kB [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 6.08 kB [entry] [rendered]
chunk {styles} styles.js, styles.js.map (styles) 16.2 kB [initial] [rendered]

ERROR in src/app/utils/custom-matchers.ts(22,37): error TS2503: Cannot find namespace 'jasmine'.
src/app/utils/custom-matchers.ts(80,30): error TS2503: Cannot find namespace 'jasmine'.
src/app/utils/helpers.ts(71,10): error TS2304: Cannot find name 'expect'.
src/app/utils/helpers.ts(92,35): error TS2304: Cannot find name 'expect'.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! testing-patterns@0.0.0 build: `ng build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the testing-patterns@0.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\user\AppData\Roaming\npm-cache\_logs\2019-08-06T13_47_40_645Z-debug.log
``